### PR TITLE
HOST config option so proxy can listen on specified interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The code is inspired by and functions mostly the same as [ln-ws-proxy](https://g
 The WebSocket server is setup to run on port 3000, but can be modified by creating a .env file and placing it in the root directory with the following var:
 
 ```
+HOST=localhost
 PORT=3000
 ```
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,6 @@
 // load env vars
+export const HOST = process.env.HOST || 'localhost'
+
 export const PORT = Number(process.env.PORT) || 3000
 
 export const MAX_SOCKET_BACKPRESSURE_BYTES = 1024 * 1024 // 1mb

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import uWS from 'uWebSockets.js'
-import { PORT, MAX_SOCKET_BACKPRESSURE_BYTES } from './constants'
+import { HOST, PORT, MAX_SOCKET_BACKPRESSURE_BYTES } from './constants'
 
 import {
   handleMessage,
@@ -28,8 +28,8 @@ async function start() {
     close: handleClose
   })
 
-  app.listen('localhost', PORT, () =>
-    console.log(`server listening on port ${PORT}`)
+  app.listen(HOST, PORT, () =>
+    console.log(`server listening on ${HOST}:${PORT}`)
   )
 }
 


### PR DESCRIPTION
This is useful if you want to deploy it inside of a docker container where it has to listen on `0.0.0.0` to be accessible from outside.